### PR TITLE
 Fix crash due to memcopy at NULL destination.

### DIFF
--- a/pam_e4crypt.c
+++ b/pam_e4crypt.c
@@ -138,6 +138,10 @@ key_list_alloc_key(
         struct ext4_encryption_key* tmp = malloc(old_size * 2);
         if (!tmp)
             return NULL;
+        if (list->data == NULL) {
+            list->data = tmp;
+            return list->data + current_pos;
+        }
         memcpy(tmp, list->data, old_size);
         memset(list->data, 0, old_size);
         free(list->data);


### PR DESCRIPTION
 When the key list is initialized its data pointer is NULL. The
 key_list_alloc() just try to copy the old keys in in data which leads to a
 crash. This patch fix this by setting the data pointer to the newly allocated
 ext4_encryption_key. The copy will only be made when really resizing the list.