### PR TITLE
Allow to have different salt by user

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Invoke this module during the authentication phase after the passphrase is
 set, so the keys can be generated, and during the session phase right after
 pam_keyinit, so the keys are added to the session keyring.
 
+User can have a specific salt stored in `$HOME/.ext4_encryption_salt`.
+You can generate this salt with one of the following commands :
+
+``` echo -n `uuidgen` > ~/.ext4_encryption_salt ```
+
+``` echo -n `head -c 16 /dev/urandom | xxd -p` > ~/.ext4_encryption_salt ```
+
 
 Dependencies
 ------------


### PR DESCRIPTION
When I started using this module, I noticed that by using the default configuration : 
   -  the salt is saved in the filesystem
   - the password is the user password

A direct consequence of that is : if 2 users happened to have the same password, one user can decrypt the data of the other one.

My solution was to allow the user to save its salt in `$HOME/.ext4_encryption_salt` and use it instead of the salt saved in the filesystem.