### PR TITLE
Make libdir settable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,10 @@ target_link_libraries(pam_e4crypt pam keyutils OpenSSL::Crypto uuid)
 
 # install the module in the same place where all the other modules should be
 # NOTE: we actually disrespect the install prefix here
-get_filename_component(LIBDIR ${PAM_LIBRARY} DIRECTORY)
+if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+    get_filename_component(CMAKE_INSTALL_LIBDIR ${PAM_LIBRARY} DIRECTORY)
+endif()
 install(TARGETS pam_e4crypt
-        LIBRARY DESTINATION "${LIBDIR}/security/"
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}/security/"
 )
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ Additional cflags and ldflags can be supplied via the `CMAKE_C_FLAGS` and
 cmake -DCMAKE_C_FLAGS="-O2 -fstack-protector=strong" <path-to-source>
 ```
 
+The module is automatically installed in a directory `security` which resides in
+the same folder as the PAM library. If those directories are symlinks on the
+target platform, the actual installation path may differ from the installation
+path originally used by PAM due to the default search order used by CMake.
+
+Albeit the module should still be found by PAM, users may choose to specify the
+library base path used for installation manually by setting the
+`CMAKE_INSTALL_LIBDIR` variable.
+
+For example, run
+```
+cmake -DCMAKE_INSTALL_LIBDIR=<lib-base-path> <path-to-source>
+```
+to prepare the module for installation to `<lib-base-path>/security/`.
+
 
 About passwords, mounts and policies
 ------------------------------------


### PR DESCRIPTION
Targets #7. Give users a chance to set the `LIBDIR` variable in order to alter the location to which the module is installed, without fiddling with the `CMakeLists.txt`. This appears to be a requirement at least for Arch-Linux users.