### PR TITLE
Mtab (Breaking changes!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,18 @@ just like `e4crypt add_key`. If you view you session keyring, e.g. using
 prefixed with "ext4:". The hexadecimal string following the prefix is the actual
 policy descriptor which you can pass to `e4crypt set_policy`.
 
+The correct process for encrypting a folder once logged in with pam_e4crypt is:
+
+```
+$ keyctl show
+Session Keyring
+ 111111111 --alswrv      0     0  keyring: _ses
+ 222222222 ----s-rv      0     0   \_ user: invocation_id
+ 333333333 --als-rv   1000  1000   \_ logon: ext4:abcdef012345678
+$ mkdir crypted
+$ e4crypt set_policy abcdef012345678 crypted
+```
+
 ## Licensing
 
 The module is currently licensed under the GPLv2. Have a look at the LICENSE

--- a/README.md
+++ b/README.md
@@ -132,13 +132,6 @@ just like `e4crypt add_key`. If you view you session keyring, e.g. using
 prefixed with "ext4:". The hexadecimal string following the prefix is the actual
 policy descriptor which you can pass to `e4crypt set_policy`.
 
-Please note that the salt is, apparently, parsed from the mtab in some way. This
-indicates that policies are actually specific to mounts to some extend. Sadly,
-there is no (good) way of telling which policy matches a specific mount.
-This module could, in theory, print or log some information about that, but
-currently, it doesn't. This may, however, change in the future.
-
-
 ## Licensing
 
 The module is currently licensed under the GPLv2. Have a look at the LICENSE

--- a/pam_e4crypt.c
+++ b/pam_e4crypt.c
@@ -623,18 +623,6 @@ pam_sm_authenticate(
         free(salt_data);
     }
 
-    // We have to generate a policy for each ext4 file system availible.
-    // Hence, we iterate over all mounted file systems and create a policy for
-    // each ext4 fs we find.
-    FILE* f = setmntent("/etc/mtab", "r");
-    struct mntent *mnt;
-    while (f && ((mnt = getmntent(f)) != NULL)) {
-        if (strcmp(mnt->mnt_type, "ext4") || access(mnt->mnt_dir, R_OK))
-            continue;
-       generate_key(flags, mnt->mnt_dir, auth_token, keys);
-    }
-    endmntent(f);
-
     return PAM_SUCCESS;
 }
 


### PR DESCRIPTION
Removes unnecessary mtab keys and improves documentation

WARNINIG: This is a breaking change if you've been encrypting
your data with the filesystem key instead of the salted one!

Create new encrypted folders using the correct key and copy or
move your data into them before upgrading.