### PR TITLE
Fix requirement on salt-size in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ encouraged making the module `optional` for that phase, at least initially.
 
 ### Salt
 
-Users _must_ provide a 16-byte salt value for generation of a key. If no salt is
-supplied, no key will be generated. By default, the (raw) salt is read from
+Users _must_ provide a salt (up to 16 bytes) for generation of a key. If no salt
+is supplied, no key will be generated. By default, the (raw) salt is read from
 `$HOME/.ext4_encryption_salt`. You can initialize this file with the following
 commands:
 


### PR DESCRIPTION
When rewriting the section about the salt in d38f4ca77ee10ba1015c1df0cb6787736a446b4c we started communicating the requirements on the salt-size more explicitely. We falsely stated, that the salt must be 16 bytes long when, in fact, it may be up to 16 bytes long.

Fixes #35.